### PR TITLE
docs: add typescript syntax to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ bun add inflight
 
 ## Usage
 
-```
+```ts
 import { InFlight } from "inflight";
 import { eq } from "drizzle-orm";
 import { users } from "./schema";


### PR DESCRIPTION
Add the ts language identifier to the Usage code block in README.md
Now, looks like this:
<img width="452" height="321" alt="image" src="https://github.com/user-attachments/assets/20e1133d-8616-4167-bf63-9ffaf31aa062" />


